### PR TITLE
Relative Values Fix

### DIFF
--- a/scripts/src/jquery.animate-enhanced.js
+++ b/scripts/src/jquery.animate-enhanced.js
@@ -372,8 +372,8 @@ Changelog:
 			if (transform && (/matrix/i).test(transform)) {
 				var explodedMatrix = transform.replace(/^matrix\(/i, '').split(/, |\)$/g);
 				translation = {
-					x: explodedMatrix[4],
-					y: explodedMatrix[5]
+					x: parseInt(explodedMatrix[4]),
+					y: parseInt(explodedMatrix[5])
 				};
 				
 				break;


### PR DESCRIPTION
Using a relative value (`-=/+=`) with `leaveTransforms = true` didn't calculate the value of the changing position. The problem was with `translate()` returning an object of strings instead of integers. Values of x & y are now being parsed as integers so the `end` value can be calculated correctly in `_interpretValue`.
