### PR TITLE
added ability to globally disable transforms

### DIFF
--- a/scripts/src/jquery.animate-enhanced.js
+++ b/scripts/src/jquery.animate-enhanced.js
@@ -145,6 +145,7 @@ Changelog:
 */
 
 (function($, originalAnimateMethod, originalStopMethod) {
+
 	// ----------
 	// Plugin variables
 	// ----------
@@ -424,7 +425,7 @@ Changelog:
 				}
 			};
 		
-		if (!cssTransitionsSupported || _isEmptyObject(prop) || _isBoxShortcut(prop) || optall.duration <= 0) {
+		if (!cssTransitionsSupported || _isEmptyObject(prop) || _isBoxShortcut(prop) || optall.duration <= 0 || (jQuery.fn.animate.defaults.avoidTransforms === true && prop['avoidTransforms'] !== false)) {
 			return originalAnimateMethod.apply(this, arguments);
 		} 
 		
@@ -570,6 +571,7 @@ Changelog:
 		});
 	};	
 	
+    jQuery.fn.animate.defaults = {};
 	
 	/**
 		@public


### PR DESCRIPTION
Added functionality to allow for:

``` javascript
jQuery.fn.animate.defaults.avoidTransforms = true;
```

This prevents global use of transforms, but allows for passing avoidTransforms:false in the properties of animate() to single out animations that should use transforms.  It helps in some complex layouts where most things still need to rely on js animation for positioning of other elements. 
