### PR TITLE
I tried to add a "unit management"

### DIFF
--- a/scripts/src/jquery.animate-enhanced.js
+++ b/scripts/src/jquery.animate-enhanced.js
@@ -206,6 +206,7 @@ Changelog:
 				left : 0
 			}
 		},
+		valUnit = 'px',
 
 		DATA_KEY = 'jQe',
 		CUBIC_BEZIER_OPEN = 'cubic-bezier(',
@@ -235,6 +236,18 @@ Changelog:
 		jQuery.expr.filters.animated = function(elem) {
 			return jQuery(elem).data('events') && jQuery(elem).data('events')[transitionEndEvent] ? true : originalAnimatedFilter.call(this, elem);
 		};
+	}
+
+
+	/**
+		@private
+		@name _getUnit
+		@function
+		@description Return unit value ("px", "%", "em" for re-use correct one when translating)
+		@param {variant} [val] Target value
+	*/
+	function _getUnit(val){
+		return val.match(/\D+$/);
 	}
 
 
@@ -435,6 +448,7 @@ Changelog:
 		@param {variant} [val]
 	*/
 	function _cleanValue(val) {
+		valUnit = _getUnit(val);
 		return parseFloat(val.replace(/px/i, ''));
 	}
 
@@ -561,7 +575,7 @@ Changelog:
 						}
 						if (isTranslatable && typeof selfCSSData.meta !== 'undefined') {
 							for (var j = 0, dir; (dir = directions[j]); ++j) {
-								restore[dir] = selfCSSData.meta[dir + '_o'] + 'px';
+								restore[dir] = selfCSSData.meta[dir + '_o'] + valUnit;
 							}
 						}
 					}
@@ -627,7 +641,7 @@ Changelog:
 							p,
 							opt.duration,
 							cssEasing,
-							isDirection && prop.avoidTransforms === true ? cleanVal + 'px' : cleanVal,
+							isDirection && prop.avoidTransforms === true ? cleanVal + valUnit : cleanVal,
 							isDirection && prop.avoidTransforms !== true,
 							isTranslatable,
 							prop.useTranslate3d === true);
@@ -731,8 +745,8 @@ Changelog:
 									var explodedMatrix = restore[prop].replace(/^matrix\(/i, '').split(/, |\)$/g);
 
 									// apply the explicit left/top props
-									restore['left'] = (parseFloat(explodedMatrix[4]) + parseFloat(self.css('left')) + 'px') || 'auto';
-									restore['top'] = (parseFloat(explodedMatrix[5]) + parseFloat(self.css('top')) + 'px') || 'auto';
+									restore['left'] = (parseFloat(explodedMatrix[4]) + parseFloat(self.css('left')) + valUnit) || 'auto';
+									restore['top'] = (parseFloat(explodedMatrix[5]) + parseFloat(self.css('top')) + valUnit) || 'auto';
 
 									// remove the transformations
 									for (i = cssPrefixes.length - 1; i >= 0; i--) {


### PR DESCRIPTION
Before the change, if asked animated value unit wasn't 'px', but for example "%" or "em", unit was replaced by "hard coded" 'px' unit : initial "%" call was transformed and animate calls with value lik "15%" became "15px".

I needed to keep the correct unit when translating, so I added a _getUnit private method, as well as a 'valUnit' variable, which is set through a_getUnit call from existing '_cleanValue' calls.

I then replaced all "hardcoded" 'px' with the valUnit variable.

It seems to do the trick for me, so perhaps is there something in that minor adjustment that could help someone else?
