### PR TITLE
Fix issue #43. The animation fades now to the css opacity value of the selector instead of 1

### DIFF
--- a/scripts/src/jquery.animate-enhanced.js
+++ b/scripts/src/jquery.animate-enhanced.js
@@ -282,21 +282,22 @@ Changelog:
 		if (prop == 'bottom') cleanStart = parseInt(cleanCSSStart, 10) + translation.y;
 
 		// deal with shortcuts
-		if (!parts && val == 'show') {
-			cleanStart = 1;
+		if(!parts) {
+			if(val === 'show') {
+				// set the css opacity as the start value
+				cleanStart = 1 * e.css('opacity');
 			if (hidden) e.css({'display':'block', 'opacity': 0});
-		} else if (!parts && val == "hide") {
-			cleanStart = 0;
-		}
-
-		if (parts) {
+			} else if (!parts && val == "hide") {
+				cleanStart = 0;
+			}
+			
+			return cleanStart;
+		} else {
 			var end = parseFloat(parts[2]);
 
 			// If a +=/-= token was provided, we're doing a relative animation
 			if (parts[1]) end = ((parts[1] === '-=' ? -1 : 1) * end) + parseInt(cleanStart, 10);
 			return end;
-		} else {
-			return cleanStart;
 		}
 	}
 


### PR DESCRIPTION
Hey Ben,

I've fixed the issue #43 in your plugin. I've tested the bug fix in Firefox 12, Chrome 18.0.1025.165 and Safari 5.1.5 (7534.55.3) using all the different jQuery versions in the contrib folder. Please make sure to check the bug fix in Internet Explorer before merging.

Kind Regards,
klarstil
