### PR TITLE
Fixed missing callback when nested animations

### DIFF
--- a/scripts/src/jquery.animate-enhanced.js
+++ b/scripts/src/jquery.animate-enhanced.js
@@ -694,7 +694,7 @@ Changelog:
 
 				// has to be done in a timeout to ensure transition properties are set
 				setTimeout(function() {
-					self.one(transitionEndEvent, cssCallback).css(secondary);
+					self.bind(transitionEndEvent, cssCallback).css(secondary);
 				});
 			}
 			else {


### PR DESCRIPTION
There was a bug when a css animation is playing, then an animate() method is called, and the first animation ends before the "animate()" one.

In this case the cssCallback is fired, but not fully executed because of the first test "e.eventPhase != 2" (which is good)

But as the callback is instantiated with "one()" it won't be executed again at the end of the real animation.

Changing "one()" to "bind()" solves this problem, and the events don't stack because of the "self.unbind(transitionEndEvent)"
So should be all good ...
