### PR TITLE
Use originalAnimateMethod if a step callback function is provided.

### DIFF
--- a/scripts/src/jquery.animate-enhanced.js
+++ b/scripts/src/jquery.animate-enhanced.js
@@ -654,7 +654,7 @@ Changelog:
 			},
 			bypassPlugin = (typeof prop['avoidCSSTransitions'] !== 'undefined') ? prop['avoidCSSTransitions'] : pluginDisabledDefault;
 
-		if (bypassPlugin === true || !cssTransitionsSupported || _isEmptyObject(prop) || _isBoxShortcut(prop) || optall.duration <= 0) {
+		if (bypassPlugin === true || !cssTransitionsSupported || _isEmptyObject(prop) || _isBoxShortcut(prop) || optall.duration <= 0 || optall.step) {
 			return originalAnimateMethod.apply(this, arguments);
 		}
 


### PR DESCRIPTION
If a step callback function is provided along with the call to animate(), the originalAnimateMethod should be used instead, since step would otherwise not be called.
