### PR TITLE
fallback for special easing that use CUBIC_BEZIER.

### DIFF
--- a/scripts/src/jquery.animate-enhanced.js
+++ b/scripts/src/jquery.animate-enhanced.js
@@ -668,8 +668,10 @@ Changelog:
 
 		if (bypassPlugin === true || !cssTransitionsSupported || _isEmptyObject(prop) || _isBoxShortcut(prop) || optall.duration <= 0 || optall.step) {
 			//fallback for special easing that use CUBIC_BEZIER.
-			if(arguments[2] !== 'linear' && arguments[2] !== 'swing'){
-				arguments[2] = 'linear'
+			if($.easing && !$.easing.hasOwnProperty(arguments[2])) {
+				if((arguments[2] !== 'linear' && arguments[2] !== 'swing') ){
+					arguments[2] = 'swing';
+				}
 			}
 			return originalAnimateMethod.apply(this, arguments);
 		}


### PR DESCRIPTION
Browsers that does not support cubic_bezier throw error:
Object doesn't support property or method 'easeOutBack'
To solve this if easing is different from swipe or linear it will be set as linear by default on old browsers
