### PR TITLE
Other units, beside '%' should also be kept

### DIFF
--- a/scripts/src/jquery.animate-enhanced.js
+++ b/scripts/src/jquery.animate-enhanced.js
@@ -348,7 +348,7 @@ Changelog:
 			if (parts[1]) end = ((parts[1] === '-=' ? -1 : 1) * end) + parseInt(cleanStart, 10);
 
 			// check for unit  as per issue #69
-			if (parts[3] == '%') end = end + '%';
+			if (parts[3] && parts[3] != 'px') end = end + parts[3];
 
 			return end;
 		} else {


### PR DESCRIPTION
Otherwise, `%`, `em` and others magically get converted to `px`
