### PR TITLE
Access element tag name appropriately

### DIFF
--- a/scripts/src/jquery.animate-enhanced.js
+++ b/scripts/src/jquery.animate-enhanced.js
@@ -357,7 +357,7 @@ Changelog:
 					// in a stylesheet to whatever the default browser style is
 					// for such an element
 					if ( display === '' && jQuery.css(elem, 'display') === 'none' ) {
-						jQuery._data(elem, 'olddisplay', _domElementVisibleDisplayValue(elem.context.tagName));
+						jQuery._data(elem, 'olddisplay', _domElementVisibleDisplayValue(elem.tagName));
 					}
 
 					if (display === '' || display === 'none') {


### PR DESCRIPTION
This fixes #146, which was introduced in be269e1.

elem is already the DOM element so we don't need to fetch "context" first.
