### PR TITLE
Added check for already hidden elements

### DIFF
--- a/scripts/src/jquery.animate-enhanced.js
+++ b/scripts/src/jquery.animate-enhanced.js
@@ -701,6 +701,11 @@ Changelog:
 		if (bypassPlugin === true || !cssTransitionsSupported || _isEmptyObject(prop) || _isBoxShortcut(prop) || optall.duration <= 0 || optall.step) {
 			return originalAnimateMethod.apply(this, arguments);
 		}
+		
+		if(prop.opacity === 'hide' && jQuery(this).is(':hidden'))
+		{
+			return originalAnimateMethod.apply(this, arguments);
+		}
 
 		return this[ optall.queue === true ? 'queue' : 'each' ](function() {
 			var self = jQuery(this),


### PR DESCRIPTION
Fix for #128

It is just needed for fadeOut elements, as for fadeIn it seems to work flawless, even on subsequent calls to fadeIn. At least in the tests I did, if someone could provide another where it does not work just post.

Problem for fadeIn or better 'prop.opacity == show' its not so easy to bypass as we would want to do CSS while opacity >= 0 to 'show' or to another opacity. We could at least check for

``` javascript
prop.opacity === 'show' && jQuery(this).css('opacity') === 1
```

but as this would add even more overhead I would suggest just to add it if it is really needed, aka some simple test example which shows the callback not to work for subsequent fadeIn's.

I think the place seems right, as we won't have called the whole cssCallback magic. It adds a bit stress though, because we need to encapsulate the DOM element inside jQuery to check for ':hidden'
