### PR TITLE
reference to not minified version of main file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "benbarnett/jQuery-Animate-Enhanced",
   "version": "1.0.7",
-  "main": "./jquery.animate-enhanced.min.js",
+  "main": "scripts/src/jquery.animate-enhanced.js",
   "description": "Extend $.animate() to detect CSS transitions for Webkit, Mozilla, IE>=10 and Opera and convert animations automatically.",
   "license": "MIT (http://opensource.org/licenses/mit-license.php)",
   "ignore": [


### PR DESCRIPTION
If this package is used within a build process (e.g. yo web app), referencing minified versions of packages will cause errors during build

This topic has been discussed multiple times... and making this change actually helped me to optimise my web application.

https://groups.google.com/forum/#!msg/twitter-bower/P8TbooJPacs/Qxy40Gcp2o0J

bower/bower#368

and even been adopted in packages like bootstrap:

twbs/bootstrap#9493
