### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "benbarnett/jQuery-Animate-Enhanced",
-  "version": "1.0.7",
   "main": "scripts/src/jquery.animate-enhanced.js",
   "description": "Extend $.animate() to detect CSS transitions for Webkit, Mozilla, IE>=10 and Opera and convert animations automatically.",
   "license": "MIT (http://opensource.org/licenses/mit-license.php)",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property