### PR TITLE
Fixed bug when applying continuous value to left, top position during animation event

### DIFF
--- a/scripts/src/jquery.animate-enhanced.js
+++ b/scripts/src/jquery.animate-enhanced.js
@@ -618,7 +618,7 @@ Changelog:
 		}
 
 		var is = jQuery.inArray(prop, cssTransitionProperties) > -1;
-		if ((prop == 'width' || prop == 'height' || prop == 'opacity') && (parseFloat(value) === parseFloat(element.css(prop)))) is = false;
+		if ((prop == 'width' || prop == 'height' || prop == 'opacity' || prop == 'left' || prop == 'top') && (parseFloat(value) === parseFloat(element.css(prop)))) is = false;
 		return is;
 	}
 


### PR DESCRIPTION
#152 Trying to animate top/left without modifying the offset moves the offset to zero
 
Fixed bug when applying continuous value to left, top position during animation event
애니메이션 이벤트 중 좌측 상단에 연속 값을 적용했을 때의 버그 수정